### PR TITLE
Provide ability to create DSK images

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,8 @@
         <activity android:name=".EmulatorActivity"
             android:theme="@style/AppThemeDark"/>
         <activity android:name=".browser.FileBrowserActivity" />
+        <activity android:name=".CreateDiskActivity"
+            android:configChanges="orientation|screenSize"/>
         <activity android:name="org.retrostore.android.RetrostoreActivity"
                   android:label="@string/retrostore_activity_name"/>
         <meta-data

--- a/app/src/main/java/org/puder/trs80/CreateDiskActivity.java
+++ b/app/src/main/java/org/puder/trs80/CreateDiskActivity.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2012-2013, Arno Puder
+ * Copyright 2017, Robert Corrigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.puder.trs80;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.design.widget.Snackbar;
+import android.support.v7.app.ActionBar;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+public class CreateDiskActivity extends BaseActivity
+        implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    public static final String MKDISK_NAME = "mkdisk_name";
+    public static final String MKDISK_FORMAT = "mkdisk_format";
+    public static final String MKDISK_SIDED = "mkdisk_sided";
+    public static final String MKDISK_DENSITY = "mkdisk_density";
+    public static final String MKDISK_SIZE = "mkdisk_size";
+    public static final String MKDISK_IGNORE_DENSITY = "mkdisk_ignore_density";
+
+    private CreateDiskFragment fragment;
+    private SharedPreferences sharedPrefs;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Dummy view. Will be replaced by CreateDiskFragment.
+        setContentView(new View(this));
+
+        ActionBar actionBar = getSupportActionBar();
+        actionBar.setDisplayHomeAsUpEnabled(true);
+
+        sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+        sharedPrefs.registerOnSharedPreferenceChangeListener(this);
+
+        clearDiskImageName();
+
+        fragment = new CreateDiskFragment();
+        getFragmentManager().beginTransaction()
+                .replace(android.R.id.content, fragment).commit();
+    }
+
+    @Override
+    protected void onDestroy() {
+        sharedPrefs.unregisterOnSharedPreferenceChangeListener(this);
+        super.onDestroy();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        menu.clear();
+        getMenuInflater().inflate(R.menu.menu_create_media, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        String diskImageName = getDiskImageName();
+        boolean enable = validateDiskImageName(diskImageName);
+
+        MenuItem create_media = menu.findItem(R.id.create_media);
+        create_media.setEnabled(enable);
+        create_media.getIcon().setAlpha(enable ? 255 : 96);
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int id = item.getItemId();
+
+        if (id == R.id.create_media) {
+            if (createDiskImage()) {
+                doneEditing(false);
+                return true;
+            }
+        } else if (id == R.id.cancel_media) {
+            doneEditing(true);
+            return true;
+        } else if (id == android.R.id.home) {
+            doneEditing(true);
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    public boolean createDiskImage() {
+        try {
+            String diskImg = getDiskImageName();
+
+            Intent i = getIntent();
+            String currentPath = i.getStringExtra("DIR");
+
+            String diskImgPath = new File(currentPath, diskImg).getCanonicalPath();
+            if (!diskImgPath.toLowerCase().endsWith(".dsk")) {
+                diskImgPath = diskImgPath.concat(".dsk");
+            }
+
+            if (new File(diskImgPath).exists()) {
+                throw new Exception(getString(R.string.mkdisk_file_exists_error));
+            }
+
+            String diskImgFormat = getDiskImageFormat();
+            boolean success = false;
+
+            if (diskImgFormat.equalsIgnoreCase(getString(R.string.mkdisk_jv1))) {
+                success = XTRS.createBlankJV1(diskImgPath);
+            } else if (diskImgFormat.equalsIgnoreCase(getString(R.string.mkdisk_jv3))) {
+                success = XTRS.createBlankJV3(diskImgPath);
+            } else if (diskImgFormat.equalsIgnoreCase(getString(R.string.mkdisk_dmk))) {
+                int diskImgSides = getDiskImageSided();
+                int diskImgDensity = getDiskImageDensity();
+                int diskImgEight = getDiskImageEight();
+                int diskImgIgnoreDensity = getDiskImageIgnoreDensity();
+
+                success = XTRS.createBlankDMK(diskImgPath, diskImgSides, diskImgDensity,
+                        diskImgEight, diskImgIgnoreDensity);
+            }
+
+            if (success) {
+                i.putExtra("PATH", diskImgPath);
+                return success;
+            } else {
+                throw new Exception(getString(R.string.mkdisk_create_error));
+            }
+        } catch (Exception e) {
+            View root = findViewById(android.R.id.content);
+            Snackbar.make(root, e.getLocalizedMessage(), Snackbar.LENGTH_SHORT).show();
+            return false;
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        doneEditing(true);
+    }
+
+    private void doneEditing(boolean cancel) {
+        setResult(cancel ? RESULT_CANCELED : RESULT_OK, getIntent());
+        clearDiskImageName();
+        finish();
+    }
+
+    private String getDiskImageName() {
+        return sharedPrefs.getString(MKDISK_NAME, "");
+    }
+    private String getDiskImageFormat() {
+        return sharedPrefs.getString(MKDISK_FORMAT, getString(R.string.mkdisk_jv1));
+    }
+    private int getDiskImageSided() {
+        String sided = sharedPrefs.getString(MKDISK_SIDED, "1");
+        return Integer.parseInt(sided);
+    }
+    private int getDiskImageDensity() {
+        String density = sharedPrefs.getString(MKDISK_DENSITY, getString(R.string.mkdisk_single));
+        return density.equalsIgnoreCase(getString(R.string.mkdisk_double)) ? 2 : 1;
+    }
+    private int getDiskImageEight() {
+        String density = sharedPrefs.getString(MKDISK_SIZE, getString(R.string.mkdisk_5_inch));
+        return density.equalsIgnoreCase(getString(R.string.mkdisk_8_inch)) ? 1 : 0;
+    }
+    private int getDiskImageIgnoreDensity() {
+        return sharedPrefs.getBoolean(MKDISK_IGNORE_DENSITY, false) ? 1 : 0;
+    }
+
+
+    public boolean validateDiskImageName(String name) {
+        return Pattern.matches("[-_.A-Za-z0-9]+", name);
+    }
+
+    private void clearDiskImageName() {
+        SharedPreferences.Editor edit = sharedPrefs.edit();
+        edit.putString(MKDISK_NAME, "");
+        edit.commit();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (key.equalsIgnoreCase(MKDISK_NAME)) {
+            invalidateOptionsMenu();
+        }
+    }
+}

--- a/app/src/main/java/org/puder/trs80/CreateDiskFragment.java
+++ b/app/src/main/java/org/puder/trs80/CreateDiskFragment.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2012-2013, Arno Puder
+ * Copyright 2017, Robert Corrigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.puder.trs80;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.os.Handler;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
+import android.view.View;
+
+import static org.puder.trs80.CreateDiskActivity.MKDISK_DENSITY;
+import static org.puder.trs80.CreateDiskActivity.MKDISK_FORMAT;
+import static org.puder.trs80.CreateDiskActivity.MKDISK_IGNORE_DENSITY;
+import static org.puder.trs80.CreateDiskActivity.MKDISK_NAME;
+import static org.puder.trs80.CreateDiskActivity.MKDISK_SIDED;
+import static org.puder.trs80.CreateDiskActivity.MKDISK_SIZE;
+
+public class CreateDiskFragment extends PreferenceFragment implements Preference.OnPreferenceChangeListener {
+
+    private Handler handler;
+
+    private SharedPreferences sharedPrefs;
+
+    private Preference name;
+    private Preference format;
+    private Preference sided;
+    private Preference density;
+    private Preference size;
+    private Preference ignoreDensity;
+
+    private String defaultNameSummary;
+    private String defaultFormatSummary;
+    private String defaultSidedSummary;
+    private String defaultDensitySummary;
+    private String defaultSizeSummary;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        handler = new Handler();
+        sharedPrefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+
+        addPreferencesFromResource(R.xml.mkdisk);
+
+        name = findPreference(MKDISK_NAME);
+        name.setOnPreferenceChangeListener(this);
+        defaultNameSummary = name.getSummary().toString();
+
+        format = findPreference(MKDISK_FORMAT);
+        format.setOnPreferenceChangeListener(this);
+        defaultFormatSummary = format.getSummary().toString();
+
+        sided = findPreference(MKDISK_SIDED);
+        sided.setOnPreferenceChangeListener(this);
+        defaultSidedSummary = sided.getSummary().toString();
+
+        density = findPreference(MKDISK_DENSITY);
+        density.setOnPreferenceChangeListener(this);
+        defaultDensitySummary = density.getSummary().toString();
+
+        size = findPreference(MKDISK_SIZE);
+        size.setOnPreferenceChangeListener(this);
+        defaultSizeSummary = size.getSummary().toString();
+
+        ignoreDensity = findPreference(MKDISK_IGNORE_DENSITY);
+        ignoreDensity.setOnPreferenceChangeListener(this);
+
+        updateSummaries();
+    }
+
+    private void updateSummaries() {
+        String val;
+
+        val = sharedPrefs.getString(MKDISK_NAME, defaultNameSummary);
+        if (val.isEmpty()) val = defaultNameSummary;
+        name.setSummary(val);
+
+        val = sharedPrefs.getString(MKDISK_FORMAT, defaultFormatSummary);
+        format.setSummary(val);
+
+        boolean dmkSelected = val.equalsIgnoreCase(getString(R.string.mkdisk_dmk));
+        getPreferenceScreen().findPreference(MKDISK_SIDED).setEnabled(dmkSelected);
+        getPreferenceScreen().findPreference(MKDISK_DENSITY).setEnabled(dmkSelected);
+        getPreferenceScreen().findPreference(MKDISK_SIZE).setEnabled(dmkSelected);
+        getPreferenceScreen().findPreference(MKDISK_IGNORE_DENSITY).setEnabled(dmkSelected);
+
+        val = sharedPrefs.getString(MKDISK_SIDED, defaultSidedSummary);
+        sided.setSummary(val);
+
+        val = sharedPrefs.getString(MKDISK_DENSITY, defaultDensitySummary);
+        density.setSummary(val);
+
+        val = sharedPrefs.getString(MKDISK_SIZE, defaultSizeSummary);
+        size.setSummary(val);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference.getKey().equalsIgnoreCase(MKDISK_NAME)) {
+            CreateDiskActivity activity = (CreateDiskActivity)getActivity();
+
+            if (!activity.validateDiskImageName(newValue.toString())) {
+                View root = activity.findViewById(android.R.id.content);
+                Snackbar.make(root, getString(R.string.mkdisk_bad_path) + newValue.toString(),
+                        Snackbar.LENGTH_SHORT).show();
+                return false;
+            }
+        }
+
+        /*
+         * When we get to this point, the preferences have not yet been updated
+         * yet. For this reason updateSummaries() is called via a handler to
+         * ensure the preferences have been updated.
+         */
+        handler.post(new Runnable() {
+
+            @Override
+            public void run() {
+                updateSummaries();
+            }
+        });
+        return true;
+    }
+}

--- a/app/src/main/java/org/puder/trs80/XTRS.java
+++ b/app/src/main/java/org/puder/trs80/XTRS.java
@@ -120,6 +120,13 @@ public class XTRS {
 
     public static native float getCassettePosition();
 
+    public static native boolean createBlankJV1(String filename);
+
+    public static native boolean createBlankJV3(String filename);
+
+    public static native boolean createBlankDMK(String filename, int sides,
+                                                int density, int eight, int ignden);
+
     public static void setEmulatorActivity(EmulatorActivity activity) {
         emulator = activity;
     }

--- a/app/src/main/java/org/puder/trs80/configuration/EmulatorState.java
+++ b/app/src/main/java/org/puder/trs80/configuration/EmulatorState.java
@@ -56,6 +56,10 @@ public class EmulatorState {
         return fileManager.getAbsolutePathForFile(FILE_CASSETTE);
     }
 
+    public String getBasePath() {
+        return fileManager.getAbsolutePathForFile("");
+    }
+
     public void saveState() {
         XTRS.saveState(getStateFileName());
     }

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -9,6 +9,7 @@ LOCAL_SRC_FILES := native.c \
 	trs_chars.c \
 	trs_printer.c \
 	trs_disk.c \
+	trs_mkdisk.c \
 	trs_rom1.c \
 	trs_imp_exp.c \
 	error.c \

--- a/app/src/main/jni/native.c
+++ b/app/src/main/jni/native.c
@@ -4,6 +4,7 @@
 #include <setjmp.h>
 #include "trs.h"
 #include "trs_disk.h"
+#include "trs_mkdisk.h"
 #include "trs_cassette.h"
 #include "trs_iodefs.h"
 #include "trs_uart.h"
@@ -335,6 +336,28 @@ jfloat Java_org_puder_trs80_XTRS_getCassettePosition(JNIEnv* e, jclass clazz) {
 JNIEXPORT jboolean JNICALL
 Java_org_puder_trs80_XTRS_isExpandedMode(JNIEnv *env, jclass type) {
     return is_expanded_mode() ? JNI_TRUE : JNI_FALSE;
+}
+
+jboolean Java_org_puder_trs80_XTRS_createBlankJV1(JNIEnv* env, jclass cls, jstring fileName) {
+    const char* fn = (*env)->GetStringUTFChars(env, fileName, NULL);
+    int rc = trs_create_blank_jv1(fn);
+    (*env)->ReleaseStringUTFChars(env, fileName, fn);
+    return (rc == 0) ? JNI_TRUE : JNI_FALSE;
+}
+
+jboolean Java_org_puder_trs80_XTRS_createBlankJV3(JNIEnv* env, jclass cls, jstring fileName) {
+    const char* fn = (*env)->GetStringUTFChars(env, fileName, NULL);
+    int rc = trs_create_blank_jv3(fn);
+    (*env)->ReleaseStringUTFChars(env, fileName, fn);
+    return (rc == 0) ? JNI_TRUE : JNI_FALSE;
+}
+
+jboolean Java_org_puder_trs80_XTRS_createBlankDMK(JNIEnv* env, jclass cls, jstring fileName,
+    jint sides, jint density, jint eight, jint ignden) {
+    const char* fn = (*env)->GetStringUTFChars(env, fileName, NULL);
+    int rc = trs_create_blank_dmk(fn, sides, density, eight, ignden);
+    (*env)->ReleaseStringUTFChars(env, fileName, fn);
+    return (rc == 0) ? JNI_TRUE : JNI_FALSE;
 }
 
 void xlog(const char* msg) {

--- a/app/src/main/jni/trs_mkdisk.c
+++ b/app/src/main/jni/trs_mkdisk.c
@@ -1,0 +1,356 @@
+/* SDLTRS version Copyright (c): 2006, Mark Grebe */
+
+/* Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+*/
+
+/* Copyright (c) 1996-98, Timothy Mann */
+
+/* This software may be copied, modified, and used for any purpose
+ * without fee, provided that (1) the above copyright notice is
+ * retained, and (2) modified versions are clearly marked as having
+ * been modified, with the modifier's name and the date included.  */
+
+/*
+   Modified by Mark Grebe, 2006
+   Last modified on Wed May 07 09:12:00 MST 2006 by markgrebe
+*/
+
+/*
+ * mkdisk.c
+ * Make a blank (unformatted) emulated floppy or hard drive in a file,
+ * or write protect/unprotect an existing one.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
+#include "trs_disk.h"
+#include "trs_hard.h"
+#include "trs_mkdisk.h"
+
+typedef unsigned char Uchar;
+#include "reed.h"
+
+#ifdef _WIN32
+#include "wtypes.h"
+#include "winnt.h"
+
+static int win_set_readonly(char *filename, int readonly)
+{
+  DWORD attr;
+  attr = GetFileAttributes(filename);
+  SetFileAttributes(filename, readonly
+		? (attr | FILE_ATTRIBUTE_READONLY)
+		: (attr & ~FILE_ATTRIBUTE_READONLY)) != 0;
+}
+#endif
+
+void trs_protect_disk(int drive, int writeprot)
+{
+  char prot_filename[FILENAME_MAX];
+  struct stat st;
+  int newmode;
+  FILE *f;
+  char *diskname;
+  int emutype = trs_disk_getdisktype(drive);
+  
+  diskname = trs_disk_getfilename(drive);
+  if (diskname[0] == 0)
+    return;
+    
+  strcpy(prot_filename, diskname);
+#ifndef _WIN32  
+  if (stat(prot_filename, &st) < 0)
+    return;
+#endif    
+  trs_disk_remove(drive);
+  
+  if (emutype == JV3 || emutype == DMK) {
+#ifdef _WIN32  
+    win_set_readonly(prot_filename,0);
+#else
+    chmod(prot_filename, st.st_mode | (S_IWUSR|S_IWGRP|S_IWOTH));
+#endif
+    f=fopen(prot_filename,"r+");
+    if (f!=NULL) {
+      if (emutype == JV3) {
+        /* Set the magic byte */
+        fseek(f, 256*34-1, 0);
+        putc(writeprot ? 0 : 0xff, f);
+      } else {
+        /* Set the magic byte */
+        putc(writeprot ? 0xff : 0, f);
+      }
+      fclose(f);  
+    }
+  }
+    
+#ifdef _WIN32  
+  win_set_readonly(prot_filename,writeprot);
+#else
+  if (writeprot) 
+    newmode = st.st_mode & ~(S_IWUSR|S_IWGRP|S_IWOTH);
+  else 
+    newmode = st.st_mode | (S_IWUSR|S_IWGRP|S_IWOTH);
+  chmod(prot_filename, newmode);
+#endif  
+  trs_disk_insert(drive,prot_filename);
+}
+
+void trs_protect_hard(int drive, int writeprot)
+{
+  char prot_filename[FILENAME_MAX];
+  struct stat st;
+  int newmode;
+  char *diskname;
+  FILE *f;
+  
+  diskname = trs_hard_getfilename(drive);
+  if (diskname[0] == 0)
+    return;
+    
+  strcpy(prot_filename, diskname);
+
+#ifndef _WIN32  
+  if (stat(prot_filename, &st) < 0)
+    return;
+#endif    
+  trs_hard_remove(drive);
+  
+#ifdef _WIN32  
+  win_set_readonly(prot_filename,0);
+#else
+  chmod(prot_filename, st.st_mode | (S_IWUSR|S_IWGRP|S_IWOTH));
+#endif
+  f=fopen(prot_filename,"r+");
+  if (f!=NULL) {
+    fseek(f, 7, 0);
+    newmode = getc(f);
+    if (newmode != EOF) {
+      newmode = (newmode & 0x7f) | (writeprot ? 0x80 : 0);
+      fseek(f, 7, 0);
+      putc(newmode, f);
+    }
+    fclose(f);  
+  }
+    
+#ifdef _WIN32  
+  win_set_readonly(prot_filename,writeprot);
+#else
+  if (writeprot) 
+    newmode = st.st_mode & ~(S_IWUSR);
+  else 
+    newmode = st.st_mode | (S_IWUSR);
+  chmod(prot_filename, newmode);
+#endif  
+  trs_hard_attach(drive,prot_filename);
+}
+
+int trs_create_blank_jv1(char *fname)
+{
+  FILE *f;
+
+  /* Unformatted JV1 disk - just an empty file! */
+  f = fopen(fname, "wb");
+  if (f == NULL) 
+	return -1;
+  fclose(f);
+  return 0;
+}
+
+int trs_create_blank_jv3(char *fname)
+{
+  FILE *f;
+  int i;
+  
+  /* Unformatted JV3 disk. */
+  f = fopen(fname, "wb");
+  if (f == NULL) 
+	return -1;
+  for (i=0; i<(256*34); i++) 
+    putc(0xff, f);
+  fclose(f);
+  return 0;
+}
+
+int trs_create_blank_dmk(char *fname, int sides, int density, 
+                         int eight, int ignden)
+{
+  FILE *f;
+  int i;
+  /* Unformatted DMK disk */
+
+  if (sides == -1) sides = 2;
+  if (density == -1) density = 2;
+
+  if (sides != 1 && sides != 2) 
+    return -1;
+	
+  if (density < 1 || density > 2)
+    return -1;
+    
+  f = fopen(fname, "wb");
+  if (f == NULL) 
+	return -1;
+  putc(0, f);           /* 0: not write protected */
+  putc(0, f);           /* 1: initially zero tracks */
+  if (eight) {
+    if (density == 1)
+       i = 0x14e0;
+    else
+       i = 0x2940;
+  } else {
+    if (density == 1)
+      i = 0x0cc0;
+    else
+      i = 0x1900;
+  }
+  putc(i & 0xff, f);    /* 2: LSB of track length */
+  putc(i >> 8, f);      /* 3: MSB of track length */
+  i = 0;
+  if (sides == 1)   i |= 0x10;
+  if (density == 1) i |= 0x40;
+  if (ignden)       i |= 0x80;
+  putc(i, f);           /* 4: options */
+  putc(0, f);           /* 5: reserved */
+  putc(0, f);           /* 6: reserved */
+  putc(0, f);           /* 7: reserved */
+  putc(0, f);           /* 8: reserved */
+  putc(0, f);           /* 9: reserved */
+  putc(0, f);           /* a: reserved */
+  putc(0, f);           /* b: reserved */
+  putc(0, f);           /* c: MBZ */
+  putc(0, f);           /* d: MBZ */
+  putc(0, f);           /* e: MBZ */
+  putc(0, f);           /* f: MBZ */
+  fclose(f);
+  return 0;
+}
+
+int trs_create_blank_hard(char *fname, int cyl, int sec, 
+                          int gran, int dir)
+{
+  FILE *f;
+  int i;
+    /* Unformatted hard disk */
+    /* We don't care about most of this header, but we generate
+       it just in case some user wants to exchange hard drives with
+       Matthew Reed's emulator or with Pete Cervasio's port of
+       xtrshard/dct to Jeff Vavasour's Model III/4 emulator.
+    */
+  time_t tt = time(0);
+  struct tm *lt = localtime(&tt);
+  ReedHardHeader rhh;
+  Uchar *rhhp;
+  int cksum;
+
+  if (cyl == -1) cyl = 202;
+  if (sec == -1) sec = 256;
+  if (gran == -1) gran = 8;
+  if (dir == -1) dir = 1;
+
+  if (cyl < 3) {
+    printf( " error: cyl < 3\n");
+    return(-1);
+  }
+  if (cyl > 256) {
+    printf( " error: cyl > 256\n");
+    return(-1);
+  }
+  if (cyl > 203) {
+    printf(
+     " warning: cyl > 203 is incompatible with XTRSHARD/DCT\n");
+  }
+  if (sec < 4) {
+    printf( " error: sec < 4\n");
+    return(-1);
+  }
+  if (sec > 256) {
+    printf( " error: sec > 256\n");
+    return(-1);
+  }
+  if (gran < 1) {
+    return(-1);
+  }
+  if (gran > 8) {
+    return(-1);
+  }
+  if (sec < gran) {
+    return(-1);
+  }
+  if (sec % gran != 0) {
+    return(-1);
+  }
+  if (sec / gran > 32) {
+    return(-1);
+  }
+  if (dir < 1) {
+    return(-1);
+  }
+  if (dir >= cyl) {
+    return(-1);
+  }
+  
+  memset(&rhh,0,sizeof(rhh));
+
+  rhh.id1 = 0x56;
+  rhh.id2 = 0xcb;
+  rhh.ver = 0x10;
+  rhh.cksum = 0;  /* init for cksum computation */
+  rhh.blks = 1;
+  rhh.mb4 = 4;
+  rhh.media = 0;
+  rhh.flag1 = 0;
+  rhh.flag2 = rhh.flag3 = 0;
+  rhh.crtr = 0x42;
+  rhh.dfmt = 0;
+  rhh.mm = lt->tm_mon + 1;
+  rhh.dd = lt->tm_mday;
+  rhh.yy = lt->tm_year;
+  rhh.dparm = 0;
+  rhh.cyl = cyl;
+  rhh.sec = sec;
+  rhh.gran = gran;
+  rhh.dcyl = dir;
+  strcpy(rhh.label, "xtrshard");
+  strcpy(rhh.filename, fname); /* note we don't limit to 8 chars */
+
+  cksum = 0;
+  rhhp = (Uchar *) &rhh;
+  for (i=0; i<=31; i++) {
+    cksum += rhhp[i];
+  }
+  rhh.cksum = ((Uchar) cksum) ^ 0x4c;
+
+  f = fopen(fname, "wb");
+  if (f == NULL) 
+    return(1);
+  fwrite(&rhh, sizeof(rhh), 1, f);
+  fclose(f);
+  return 0;
+}
+
+

--- a/app/src/main/jni/trs_mkdisk.h
+++ b/app/src/main/jni/trs_mkdisk.h
@@ -1,0 +1,37 @@
+/* Copyright (c): 2006, Mark Grebe */
+
+/* Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+*/
+
+/*
+   Last modified on Wed May 07 09:12:00 MST 2006 by markgrebe
+*/
+
+void trs_protect_disk(int drive, int writeprot);
+void trs_protect_hard(int drive, int writeprot);
+int trs_create_blank_jv1(char *fname);
+int trs_create_blank_jv3(char *fname);
+int trs_create_blank_dmk(char *fname, int sides, int density, 
+                         int eight, int ignden);
+int trs_create_blank_hard(char *fname, int cyl, int sec, 
+                          int gran, int dir);
+

--- a/app/src/main/res/drawable/file_icon_black.xml
+++ b/app/src/main/res/drawable/file_icon_black.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.80" android:height="36dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM16,18L8,18v-2h8v2zM16,14L8,14v-2h8v2zM13,9L13,3.5L18.5,9L13,9z"/>
+</vector>

--- a/app/src/main/res/menu/menu_create_media.xml
+++ b/app/src/main/res/menu/menu_create_media.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/cancel_media"
+        android:icon="@drawable/cancel_icon"
+        android:orderInCategory="50"
+        android:title="@string/menu_cancel"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/create_media"
+        android:icon="@drawable/file_icon_black"
+        android:orderInCategory="100"
+        android:title="@string/menu_create"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -206,4 +206,26 @@
     <string name="navigation_drawer_close">Leiste geschlossen</string>
     <string name="error_msg_localstore_init">Lokaler Speicher konnte nicht initialisert werden</string>
     <string name="successfully_installed">\'%1$s\' erfolgreich installiert.</string>
+    <string name="disk_image_created">Created disk image</string>
+    <string name="mkdisk_5_inch">5 inch</string>
+    <string name="mkdisk_8_inch">8 inch</string>
+    <string name="mkdisk_bad_path">Illegal file name: </string>
+    <string name="mkdisk_create_error">Error creating disk image</string>
+    <string name="mkdisk_double">Double</string>
+    <string name="mkdisk_single">Single</string>
+    <string name="pref_mkdisk_general">General</string>
+    <string name="pref_mkdisk_name_summary">Name of the disk image file</string>
+    <string name="pref_mkdisk_name_title">Name</string>
+    <string name="pref_mkdisk_format_title">Disk format</string>
+    <string name="pref_mkdisk_format_summary">The disk format to use (JV1, JV3 or DMK)</string>
+    <string name="pref_mkdisk_dmk_parameters">DMK Parameters</string>
+    <string name="pref_mkdisk_sided_title">Number of sides</string>
+    <string name="pref_mkdisk_sided_summary">Single or double sided</string>
+    <string name="pref_mkdisk_density_title">Density</string>
+    <string name="pref_mkdisk_density_summary">Single or double density</string>
+    <string name="pref_mkdisk_size_title">Size</string>
+    <string name="pref_mkdisk_size_summary">5 or 8 inch disk</string>
+    <string name="pref_mkdisk_ignore_density_title">Ignore density flag</string>
+    <string name="mkdisk_file_exists_error">A disk image already exists with that file name</string>
+    <string name="menu_create">Create</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,4 +30,21 @@
         <item>3</item>
         <item>4</item>
     </string-array>
+    <string-array name="mkdisk_format">
+        <item>@string/mkdisk_jv1</item>
+        <item>@string/mkdisk_jv3</item>
+        <item>@string/mkdisk_dmk</item>
+    </string-array>
+    <string-array name="mkdisk_sided">
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="mkdisk_density">
+        <item>@string/mkdisk_single</item>
+        <item>@string/mkdisk_double</item>
+    </string-array>
+    <string-array name="mkdisk_size">
+        <item>@string/mkdisk_5_inch</item>
+        <item>@string/mkdisk_8_inch</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,11 +133,38 @@
     <string name="menu_tutorial">TRS-80 Tutorial</string>
     <string name="rewinding_cassette">Rewinding cassette&#8230;</string>
 
+    <!-- CreateDiskActivity -->
+    <string name="menu_create">Create</string>
+    <string name="mkdisk_jv1" translatable="false">JV1</string>
+    <string name="mkdisk_jv3" translatable="false">JV3</string>
+    <string name="mkdisk_dmk" translatable="false">DMK</string>
+    <string name="mkdisk_single">Single</string>
+    <string name="mkdisk_double">Double</string>
+    <string name="mkdisk_5_inch">5 inch</string>
+    <string name="mkdisk_8_inch">8 inch</string>
+    <string name="mkdisk_create_error">Error creating disk image</string>
+    <string name="mkdisk_bad_path">Illegal file name: </string>
+    <string name="pref_mkdisk_general">General</string>
+    <string name="pref_mkdisk_name_summary">Name of the disk image file</string>
+    <string name="pref_mkdisk_name_title">Name</string>
+    <string name="pref_mkdisk_format_title">Disk format</string>
+    <string name="pref_mkdisk_format_summary">The disk format to use (JV1, JV3 or DMK)</string>
+    <string name="pref_mkdisk_dmk_parameters">DMK Parameters</string>
+    <string name="pref_mkdisk_sided_title">Number of sides</string>
+    <string name="pref_mkdisk_sided_summary">Single or double sided</string>
+    <string name="pref_mkdisk_density_title">Density</string>
+    <string name="pref_mkdisk_density_summary">Single or double density</string>
+    <string name="pref_mkdisk_size_title">Size</string>
+    <string name="pref_mkdisk_size_summary">5 or 8 inch disk</string>
+    <string name="pref_mkdisk_ignore_density_title">Ignore density flag</string>
+
+
     <!-- FileBrowserActivity -->
     <string name="menu_cancel">Cancel</string>
     <string name="menu_eject">Eject</string>
     <string name="path">Path</string>
     <string name="alert_dialog_confirm_eject">Do you want to eject the currently mounted file?</string>
+    <string name="disk_image_created">Created disk image </string>
 
     <string name="error_model_not_supported">Only Model I and Model III are supported at this time.</string>
     <string name="error_no_rom">No valid ROM found. Please use Settings to set ROM.</string>
@@ -248,4 +275,5 @@
     <string name="navigation_drawer_caption" translatable="false">TRS-80 Emulator</string>
     <string name="error_msg_localstore_init">Cannot initialize local storage</string>
     <string name="successfully_installed">Successfully installed \'%1$s\'.</string>
+    <string name="mkdisk_file_exists_error">A disk image already exists with that file name</string>
 </resources>

--- a/app/src/main/res/xml/mkdisk.xml
+++ b/app/src/main/res/xml/mkdisk.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory android:title="@string/pref_mkdisk_general">
+
+        <EditTextPreference
+            android:inputType="text|textUri"
+            android:key="mkdisk_name"
+            android:summary="@string/pref_mkdisk_name_summary"
+            android:title="@string/pref_mkdisk_name_title" />
+    </PreferenceCategory>
+    <ListPreference
+        android:defaultValue="@string/mkdisk_jv1"
+        android:entries="@array/mkdisk_format"
+        android:entryValues="@array/mkdisk_format"
+        android:key="mkdisk_format"
+        android:title="@string/pref_mkdisk_format_title"
+        android:summary="@string/pref_mkdisk_format_summary"/>
+    <PreferenceCategory android:title="@string/pref_mkdisk_dmk_parameters">
+    <ListPreference
+        android:defaultValue="1"
+        android:entries="@array/mkdisk_sided"
+        android:entryValues="@array/mkdisk_sided"
+        android:key="mkdisk_sided"
+        android:title="@string/pref_mkdisk_sided_title"
+        android:summary="@string/pref_mkdisk_sided_summary"/>
+    <ListPreference
+        android:defaultValue="@string/mkdisk_single"
+        android:entries="@array/mkdisk_density"
+        android:entryValues="@array/mkdisk_density"
+        android:key="mkdisk_density"
+        android:title="@string/pref_mkdisk_density_title"
+        android:summary="@string/pref_mkdisk_density_summary"/>
+    <ListPreference
+        android:defaultValue="@string/mkdisk_5_inch"
+        android:entries="@array/mkdisk_size"
+        android:entryValues="@array/mkdisk_size"
+        android:key="mkdisk_size"
+        android:title="@string/pref_mkdisk_size_title"
+        android:summary="@string/pref_mkdisk_size_summary" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="mkdisk_ignore_density"
+        android:title="@string/pref_mkdisk_ignore_density_title" />
+    </PreferenceCategory>
+</PreferenceScreen>


### PR DESCRIPTION
Hey guys, I'm having a lot of fun with your emulator, but I found the inability to create my own disk images a bit of a limiting factor. So after getting back from your talk at Tandy Assembly I figured I'd implement that and contribute it back to the project.

What do you think?

Additions:
Adds the disk image creation code from sdltrs
Adds JNI methods to XTRS to call the disk image creation functions
Adds new CreateDisk Activity and Fragment to provide a UI for disk image creation
Adds a + (Add) button to the FileBrowserActivity to allow access to the new disk image creation UI
Adds a dark version of the file icon to serve as the “Create” button in the CreateDiskActivity menu. The menu option is disabled until a valid file name is entered.
Adds getBasePath() method to the EmulatorState class so other classes can easily find the root folder of the targeted emulator instance. 

Modifications:
When entering the FileBrowserActivity from the configuration editor, open in the folder of the selected image, or in the root folder for the configured emulator instance if the slot is empty. 

Notes on disk image creation:
The only characters allowed in disk image names are A-Z, a-z, 0-9, . (period), - (hyphen) and _ (underscore). 
The user is not required to specify a .dsk extension; if none is provided, it will be automatically added to the image name before creation.


